### PR TITLE
deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 node_modules/
 website/
 test*
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "html-to-hyperscript",
+  "version": "0.6.1",
+  "description": "Convert HTML to HyperScript (both syntaxes)",
+  "author": {
+    "name": "Ivan Kleshnin",
+    "email": "ivan@paqmind.com",
+    "url": "paqmind.com"
+  },
+  "keywords": [
+    "html",
+    "hyperscript"
+  ],
+  "main": "src/index.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "dependencies": {
+    "parse5": "^3.0.2",
+    "ramda": "^0.22.1"
+  },
+  "keywords": [
+    "functional"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "node_modules",
+    "bower_components"
+  ]
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,18 @@
-let {addIndex, append, contains, curry, filter, find, identity, join, map, pipe, reduce, reject, sortBy} = require("ramda")
+var addIndex = require("ramda/src/addIndex");
+var append = require("ramda/src/append");
+var contains = require("ramda/src/contains");
+var curry = require("ramda/src/curry");
+var filter = require("ramda/src/filter");
+var find = require("ramda/src/find");
+var identity = require("ramda/src/identity");
+var join = require("ramda/src/join");
+var map = require("ramda/src/map");
+var pipe = require("ramda/src/pipe");
+var reduce = require("ramda/src/reduce");
+var reject = require("ramda/src/reject");
+var sortBy = require("ramda/src/sortBy");
+
+// let {addIndex, append, contains, curry, filter, find, identity, join, map, pipe, reduce, reject, sortBy} = require("ramda")
 
 let mapIndexed = addIndex(map)
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,24 @@
-let {assoc, assocPath, append, contains, curry, drop, dropWhile, identity, join, keys} = require("ramda")
-let {map, merge, pipe, prepend, split, reduce, repeat, replace, takeWhile, trim} = require("ramda")
+let assoc = require("ramda/src/assoc");
+let assocPath = require("ramda/src/assocPath");
+let append = require("ramda/src/append");
+let contains = require("ramda/src/contains");
+let curry = require("ramda/src/curry");
+let drop = require("ramda/src/drop");
+let dropWhile = require("ramda/src/dropWhile");
+let identity = require("ramda/src/identity");
+let join = require("ramda/src/join");
+let keys = require("ramda/src/keys");
+let map = require("ramda/src/map");
+let merge = require("ramda/src/merge");
+let pipe = require("ramda/src/pipe");
+let prepend = require("ramda/src/prepend");
+let split = require("ramda/src/split");
+let reduce = require("ramda/src/reduce");
+let repeat = require("ramda/src/repeat");
+let replace = require("ramda/src/replace");
+let takeWhile = require("ramda/src/takeWhile");
+let trim = require("ramda/src/trim");
+
 let parse5 = require("parse5")
 let {mapIndexed, reduceIndexed, dropEmpty, joinNonEmpty, commonSort, filterNames, rejectNames, findName, addName} = require("./helpers")
 let inline = require("./inline")

--- a/src/index.js
+++ b/src/index.js
@@ -34,10 +34,20 @@ let normalizeAttrs = function (attrs) {
   )(rejectNames(["class", "classname", "for", "htmlfor"], attrs))
 }
 
+let CSSRuleTextToObject = function (CSSText) {
+    let regex = /([\w-]*)\s*:\s*([^;]*)/g;
+    let match;
+    let obj = {};
+    while(match = regex.exec(CSSText)) {
+        obj[match[1]] = match[2].trim();
+    }
+    return obj;
+}
+
 let attributesSelector = (item) => {
   switch (item.name) {
     case "id":    return assoc("id", item.value)
-    case "style": return assoc("style", item.value)
+    case "style": return assoc("style", CSSRuleTextToObject(item.value))
     default:      return assocPath(["attributes", item.name], item.value)
   }
 }


### PR DESCRIPTION
Virtual DOM (and perhaps other hyperscript implementations, I'm not intimately familiar with the "spec"), expects the style attribute in object form. This commit parses the CSS string into an object using a simple regex-based function.