### PR TITLE
parse value for style attribute into object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,10 +34,20 @@ let normalizeAttrs = function (attrs) {
   )(rejectNames(["class", "classname", "for", "htmlfor"], attrs))
 }
 
+let CSSRuleTextToObject = function (CSSText) {
+    let regex = /([\w-]*)\s*:\s*([^;]*)/g;
+    let match;
+    let obj = {};
+    while(match = regex.exec(CSSText)) {
+        obj[match[1]] = match[2].trim();
+    }
+    return obj;
+}
+
 let attributesSelector = (item) => {
   switch (item.name) {
     case "id":    return assoc("id", item.value)
-    case "style": return assoc("style", item.value)
+    case "style": return assoc("style", CSSRuleTextToObject(item.value))
     default:      return assocPath(["attributes", item.name], item.value)
   }
 }


### PR DESCRIPTION
Originally opened here: https://github.com/ivan-kleshnin/html-to-hyperscript/pull/4, recreating to isolate this feature

Virtual DOM (and perhaps other hyperscript implementations, I'm not intimately familiar with the "spec"), expects the style attribute in object form. This commit parses the CSS string into an object using a simple regex-based function.